### PR TITLE
Add first pass at Unit and Performance testing

### DIFF
--- a/Assets/Settings/URP-HighFidelity-Renderer.asset
+++ b/Assets/Settings/URP-HighFidelity-Renderer.asset
@@ -43,6 +43,7 @@ MonoBehaviour:
   m_RendererFeatureMap: adc0de57c6d2eee5
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
   shaders:
     blitPS: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}
     copyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
@@ -58,7 +59,7 @@ MonoBehaviour:
       type: 3}
     objectMotionVector: {fileID: 4800000, guid: 7b3ede40266cd49a395def176e1bc486,
       type: 3}
-  m_AssetVersion: 1
+  m_AssetVersion: 2
   m_OpaqueLayerMask:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -75,6 +76,7 @@ MonoBehaviour:
   m_ShadowTransparentReceive: 1
   m_RenderingMode: 0
   m_DepthPrimingMode: 1
+  m_CopyDepthMode: 0
   m_AccurateGbufferNormals: 0
   m_ClusteredRendering: 0
   m_TileSize: 32

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fc6a05ac55166c44a900e1faf456f9b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/CacheTests.cs
+++ b/Assets/Tests/CacheTests.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using NUnit.Framework;
+
+namespace SliceyMesh
+{
+    public class CacheTests : TestBase
+    {
+
+        [Test]
+        public void CanonicalIsSharedBetweenMatchingConfigs()
+        {
+            var configBase = new SliceyConfig()
+            {
+                Type = SliceyMesh.SliceyMeshType.CuboidSpherical,
+                Size = new Vector3(1, 1, 1),
+                Radii = new Vector4(0.25f, 0f, 0f, 0f),
+                Quality = 1f
+            };
+
+            var configA = configBase;
+            var configB = configBase;
+            var configC = configBase;
+
+            configA.Size = new Vector3(2, 1, 1);
+            configB.Size = new Vector3(3, 1, 1);
+            configC.Size = new Vector3(4, 1, 1);
+
+            Cache.Get(configA);
+            Cache.Get(configB);
+            Cache.Get(configC);
+
+            //1 per config plus 1 for the shared canonical version
+            Assert.That(Cache.Count, Is.EqualTo(4));
+        }
+    }
+}

--- a/Assets/Tests/CacheTests.cs.meta
+++ b/Assets/Tests/CacheTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7dd3319cb1f9f1443ab55db111a2fc68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PerformanceTests.cs
+++ b/Assets/Tests/PerformanceTests.cs
@@ -1,0 +1,88 @@
+using UnityEngine;
+using Unity.PerformanceTesting;
+using NUnit.Framework;
+
+namespace SliceyMesh
+{
+
+    public class PerformanceTests : TestBase
+    {
+
+        [Test, Performance]
+        public void CacheMiss([Values(0.25f, 0.5f, 0.75f, 1.0f)] float quality)
+        {
+            var config = new SliceyConfig()
+            {
+                Type = SliceyMesh.SliceyMeshType.CuboidSpherical,
+                Size = new Vector3(1, 1, 1),
+                Radii = new Vector4(0.25f, 0f, 0f, 0f),
+                Quality = quality
+            };
+
+            Measure.Method(() =>
+            {
+                Cache.Get(config);
+            }).
+            SetUp(() =>
+            {
+                Cache.Clear();
+            }).
+            WarmupCount(5).
+            IterationsPerMeasurement(1).
+            MeasurementCount(100).
+            Run();
+        }
+
+        [Test, Performance]
+        public void CacheHit([Values(0.25f, 0.5f, 0.75f, 1.0f)] float quality)
+        {
+            var config = new SliceyConfig()
+            {
+                Type = SliceyMesh.SliceyMeshType.CuboidSpherical,
+                Size = new Vector3(1, 1, 1),
+                Radii = new Vector4(0.25f, 0f, 0f, 0f),
+                Quality = quality
+            };
+            Cache.Get(config);
+
+            Measure.Method(() =>
+            {
+                Cache.Get(config);
+            }).
+            WarmupCount(5).
+            IterationsPerMeasurement(1).
+            MeasurementCount(100).
+            Run();
+        }
+
+        [Test, Performance]
+        public void CanonicalCacheHit([Values(0.25f, 0.5f, 0.75f, 1.0f)] float quality)
+        {
+            var configA = new SliceyConfig()
+            {
+                Type = SliceyMesh.SliceyMeshType.CuboidSpherical,
+                Size = new Vector3(1, 1, 1),
+                Radii = new Vector4(0.25f, 0f, 0f, 0f),
+                Quality = quality
+            };
+
+            //Different size but should share canonical with configA
+            var configB = configA;
+            configB.Size = new Vector3(2, 2, 2);
+
+            Measure.Method(() =>
+            {
+                Cache.Get(configB);
+            }).
+            SetUp(() =>
+            {
+                Cache.Clear();
+                Cache.Get(configA);
+            }).
+            WarmupCount(5).
+            IterationsPerMeasurement(1).
+            MeasurementCount(100).
+            Run();
+        }
+    }
+}

--- a/Assets/Tests/PerformanceTests.cs.meta
+++ b/Assets/Tests/PerformanceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a7bddc21a7e40640a77a9240b5ccb7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/TestBase.cs
+++ b/Assets/Tests/TestBase.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using Unity.PerformanceTesting;
+using UnityEngine;
+
+namespace SliceyMesh
+{
+    public class TestBase
+    {
+        public SliceyCache Cache;
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            GameObject cacheObj = new GameObject("SliceyCache");
+            Cache = cacheObj.AddComponent<SliceyCache>();
+            Cache.LogFlags = SliceyCache.SliceyCacheLogFlags.None;
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            Object.DestroyImmediate(Cache.gameObject);
+        }
+    }
+}

--- a/Assets/Tests/TestBase.cs.meta
+++ b/Assets/Tests/TestBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fca0da2ed0ee5af459d6f79a726213a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Tests.asmdef
+++ b/Assets/Tests/Tests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Unity.PerformanceTesting",
+        "Slicey Mesh"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Tests.asmdef.meta
+++ b/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 028696beea6c1aa4bb17b48b0c84b18a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.brandf.sliceymesh/Scripts/SliceyCache.cs
+++ b/Packages/com.brandf.sliceymesh/Scripts/SliceyCache.cs
@@ -79,6 +79,8 @@ namespace SliceyMesh
 
         public static SliceyCache DefaultCache { get; internal set; }
 
+        public int Count => _cache.Count;
+
 #if UNITY_EDITOR
         void OnEnable()
         {
@@ -96,6 +98,11 @@ namespace SliceyMesh
             if (LogFlags != SliceyCacheLogFlags.None) Debug.Log($"{nameof(SliceyCache)} - Clearing due to Assembly Reload");
         }
 #endif
+        
+        public void Clear()
+        {
+            _cache.Clear();
+        }
 
         public (Mesh, SliceyShaderParameters) Get(SliceyConfig config)
         {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,13 +1,14 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "2.0.3",
-    "com.unity.ide.rider": "3.0.20",
+	"com.unity.test-framework.performance": "3.0.0-pre.2",
+    "com.unity.collab-proxy": "2.0.4",
+    "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.render-pipelines.universal": "12.1.11",
-    "com.unity.test-framework": "1.1.31",
+    "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
-    "com.unity.timeline": "1.6.4",
+    "com.unity.timeline": "1.6.5",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.8.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -16,7 +16,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -30,7 +30,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.20",
+      "version": "3.0.21",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -99,12 +99,22 @@
       }
     },
     "com.unity.test-framework": {
-      "version": "1.1.31",
+      "version": "1.1.33",
       "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework.performance": {
+      "version": "3.0.0-pre.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.31",
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -119,7 +129,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.timeline": {
-      "version": "1.6.4",
+      "version": "1.6.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -76,7 +76,7 @@ PlayerSettings:
   androidFullscreenMode: 1
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.24f1
-m_EditorVersionWithRevision: 2021.3.24f1 (cf10dcf7010d)
+m_EditorVersion: 2021.3.26f1
+m_EditorVersionWithRevision: 2021.3.26f1 (a16dc32e0ff2)


### PR DESCRIPTION
Adds Unit and Performance testing using the Unity provided packages.  This is just a first pass, but this PR sets up a Tests folder in the Assets folder (so as not to pollute the main package with tests people don't need) and adds in a few tests to start, which can be modified over time.

The tests are 'Playmode' tests, which should allow them to be run on device as well, to get real-world measurements for how things are performing.

The tests are currently failing due to a bug with how canonical caching is done, but that is outside the scope of this PR
![image](https://github.com/brandf/SliceyMesh/assets/5723312/66aa39f5-308c-4b90-8ebd-f1b7fc7071da)
